### PR TITLE
Fix message sender pastie link

### DIFF
--- a/app/assets/javascripts/backbone/views/chatbox.js.coffee
+++ b/app/assets/javascripts/backbone/views/chatbox.js.coffee
@@ -28,13 +28,14 @@ class Kandan.Views.Chatbox extends Backbone.View
     })
 
     $chatbox.val("")
-    Kandan.Helpers.Channels.addActivity(
-      _.extend(activity.toJSON(), {cid: activity.cid, user: Kandan.Data.Users.currentUser()}, created_at: new Date()),
-      Kandan.Helpers.Activities.ACTIVE_STATE,
-      true
-    )
 
     activity.save({},{success: (model, response)->
+      Kandan.Helpers.Channels.addActivity(
+        _.extend(activity.toJSON(), {cid: activity.cid, user: Kandan.Data.Users.currentUser()}, created_at: new Date()),
+        Kandan.Helpers.Activities.ACTIVE_STATE,
+        true
+      )
+
       $("#activity-c#{model.cid}").attr("id", "activity-#{model.get('id')}")
       $scrollbox = $(event.target).parent().find(".paginated-activities")
       $scrollbox.prop("scrollTop", $scrollbox.prop('scrollHeight'))


### PR DESCRIPTION
When sending a message, activity was being pushed to the channel before saved. 

As no id was setted yet, if message is to be truncated by the PastiePlugin, the pastie's link, from the message sender's perspective, was broken with an undefined id in it's URL.
