### PR TITLE
Fix for #82

### DIFF
--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -12,7 +12,7 @@ class ChannelsController < ApplicationController
       more_activities = (channel.activities.count > Kandan::Config.options[:per_page])
       channel.activities.order('id DESC').includes(:user).page.each do |activity|
         activities.push activity.attributes.merge({
-          :user => activity.user.as_json(:only => [:id, :ido_id, :email, :first_name, :last_name, :gravatar_hash, :active, :locale])
+          :user => activity.user_or_deleted_user.as_json(:only => [:id, :ido_id, :email, :first_name, :last_name, :gravatar_hash, :active, :locale, :username])
         })
       end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,4 +3,8 @@ class Activity < ActiveRecord::Base
   belongs_to :channel
 
   paginates_per Kandan::Config.options[:per_page]
+
+  def user_or_deleted_user
+  	self.user || User.deleted_user
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,4 +26,11 @@ class User < ActiveRecord::Base
     super && active?
   end
 
+  def self.deleted_user
+    dummy_user = new(:username => "Deleted User", :gravatar_hash => "", :email => "")
+    dummy_user.active = false
+
+    return dummy_user
+  end
+
 end


### PR DESCRIPTION
Added dummy deleted user to be used when a message that should be shown is associated with a user that has been deleted
