### PR TITLE
Allow configuration of avatar URL (#134)

### DIFF
--- a/app/assets/javascripts/backbone/helpers/avatars.js.coffee
+++ b/app/assets/javascripts/backbone/helpers/avatars.js.coffee
@@ -1,0 +1,8 @@
+class Kandan.Helpers.Avatars
+  @urlFor: (a, options) ->
+    size = options.size || 30
+    fallback = options.fallback || Kandan.options.avatarFallback || 'mm'
+    avatarHash = a.gravatar_hash || a.get('user').gravatar_hash || a.get('gravatarHash')
+    Kandan.options.avatarUrl.replace(/%{hash}/, avatarHash).
+      replace(/%{size}/, size).
+      replace(/%{fallback}/, fallback)

--- a/app/assets/javascripts/backbone/kandan.js.coffee.erb
+++ b/app/assets/javascripts/backbone/kandan.js.coffee.erb
@@ -21,6 +21,8 @@ window.Kandan =
     perPage    : <%= Kandan::Config.options[:per_page] %>
     nowThreshold: 3000
     timestampRefreshInterval: 2000
+    avatarUrl: "<%= Kandan::Config.options[:avatar_url] %>"
+    avatarFallback: "<%= Kandan::Config.options[:avatar_fallback] %>"
 
 
   # TODO this is a helper method to register plugins

--- a/app/assets/javascripts/backbone/plugins/user_list.js.coffee
+++ b/app/assets/javascripts/backbone/plugins/user_list.js.coffee
@@ -6,7 +6,7 @@ class Kandan.Plugins.UserList
 
   @template: _.template '''
     <div class="user clearfix">
-      <img class="avatar" src="http://gravatar.com/avatar/<%= gravatarHash %>?s=25"/>
+      <img class="avatar" src="<%= avatarUrl %>"/>
       <span class="name"><%= name %></span>
     </div>
   '''
@@ -22,7 +22,7 @@ class Kandan.Plugins.UserList
 
       $users.append @template({
         name: displayName,
-        gravatarHash: user.gravatar_hash
+        avatarUrl: Kandan.Helpers.Avatars.urlFor(user, {size: 25})
       })
     $el.html($users)
 

--- a/app/assets/javascripts/backbone/views/show_activity.js.coffee
+++ b/app/assets/javascripts/backbone/views/show_activity.js.coffee
@@ -6,6 +6,7 @@ class Kandan.Views.ShowActivity extends Backbone.View
   render: ()->
     activity = @options.activity.toJSON()
     activity.content = _.escape(activity.content)
+    activity.avatarUrl = Kandan.Helpers.Avatars.urlFor(@options.activity, {size: 30})
     if activity.action != "message"
       @compiledTemplate = JST['user_notification']({activity: activity})
     else
@@ -20,10 +21,10 @@ class Kandan.Views.ShowActivity extends Backbone.View
 
       user_mention_regex = new RegExp("@#{Kandan.Helpers.Users.currentUser().username}\\b")
       all_mention_regex = new RegExp("@all")
-      
+
       if activity.user.id == Kandan.Helpers.Users.currentUser().id
         $(@el).addClass("current_user")
-      
+
       if user_mention_regex.test(@compiledTemplate) || all_mention_regex.test(@compiledTemplate)
         $(@el).addClass("mentioned_user")
 

--- a/app/assets/templates/activity_base.jst.eco
+++ b/app/assets/templates/activity_base.jst.eco
@@ -1,7 +1,7 @@
 <span class="posted_at">
   <%= new Date(@activity.created_at).toRelativeTime(Kandan.options.nowThreshold) %>
 </span>
-<img class="avatar" src="http://gravatar.com/avatar/<%= @activity.user.gravatar_hash %>?s=30"/>
+<img class="avatar" src="<%= @activity.avatarUrl %>"/>
 
 <div class="readable">
   <div class="content">

--- a/app/assets/templates/current_user.jst.eco
+++ b/app/assets/templates/current_user.jst.eco
@@ -1,2 +1,0 @@
-<img src="http://gravatar.com/avatar/<%= @gravatarHash %>?s=25"/>
-<span><%= @name %></span>

--- a/app/assets/templates/message.jst.eco
+++ b/app/assets/templates/message.jst.eco
@@ -1,7 +1,7 @@
 <span class="posted_at">
   <%= new Date(@activity.created_at).toRelativeTime(Kandan.options.nowThreshold) %>
 </span>
-<img class="avatar" src="http://gravatar.com/avatar/<%= @activity.user.gravatar_hash %>?s=30"/>
+<img class="avatar" src="<%= @activity.avatarUrl %>"/>
 
 <div class="readable">
   <span class="user">

--- a/app/assets/templates/user_notification.jst.eco
+++ b/app/assets/templates/user_notification.jst.eco
@@ -1,7 +1,7 @@
 <span class="posted_at">
   <%= new Date(@activity.created_at).toRelativeTime(Kandan.options.nowThreshold) %>
 </span>
-<img class="avatar" src="http://gravatar.com/avatar/<%= @activity.user.gravatar_hash %>?s=30"/>
+<img class="avatar" src="<%= @activity.avatarUrl %>"/>
 
 <div class="readable">
   <span class="user">Kandan bot</span>

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -1,0 +1,7 @@
+module AvatarHelper
+  def avatar_url_for(user, options = {})
+    Kandan::Config.options[:avatar_url].gsub(/%{hash}/, user.gravatar_hash).
+      gsub(/%{size}/, (options[:size] || 30).to_s).
+      gsub(/%{fallback}/, options[:fallback] || Kandan::Config.options[:avatar_fallback] || 'mm')
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
         <a href="#" class="user_menu_link">
           <cite class="user_flag"></cite>
           <div class="user">
-            <img src="http://gravatar.com/avatar/<%= current_user.gravatar_hash %>?s=25"/>
+            <img src="<%= avatar_url_for(current_user, :size => 25) %>"/>
             <span><%= current_user.full_name_or_username %></span>
           </div>
         </a>

--- a/config/kandan_settings.yml
+++ b/config/kandan_settings.yml
@@ -13,3 +13,6 @@
 :max_rooms: 99
 
 :public_site: true
+
+:avatar_url: http://gravatar.com/avatar/%{hash}?s=%{size}&d=%{fallback}
+:avatar_fallback: identicon


### PR DESCRIPTION
This PR continues the work performed so far in #134, adding a facility to allow configuration of the URL which is to be used for retrieving a user's avatar, including selection of an alternative fallback.
