### PR TITLE
Remove 'delete channel' button from primary channel ('Lobby')

### DIFF
--- a/app/assets/templates/channel_tabs.jst.eco
+++ b/app/assets/templates/channel_tabs.jst.eco
@@ -5,7 +5,9 @@
     <span class="tab_left"></span>
     <span class="tab_content">	
       <cite><%= channel.get('name') %></cite>
-      <cite class="close_channel" title="close channel">x</cite>
+      <% unless channel.get('id') == 1: %>
+        <cite class="close_channel" title="close channel">x</cite>
+      <% end %>
     </span>
   </a>	
   </li>


### PR DESCRIPTION
This PR modifies the `channel_tabs` template in order to suppress the rendering of the 'delete channel' button for the immutable primary channel.
