### PR TITLE
Enhanced notifications (#133)

### DIFF
--- a/app/assets/javascripts/backbone/helpers/channels.js.coffee
+++ b/app/assets/javascripts/backbone/helpers/channels.js.coffee
@@ -135,7 +135,7 @@ class Kandan.Helpers.Channels
 
     if not local and @getActiveChannelId() == activityAttributes.channel_id and activityAttributes.action == "message" and Kandan.Helpers.Utils.browserTabFocused != true
       Kandan.Helpers.Utils.notifyInTitle()
-      Kandan.Plugins.Notifications.playAudioNotification()
+      Kandan.Plugins.Notifications.playAudioNotification('channel')
       Kandan.Plugins.Notifications.displayNotification(activityAttributes.user.username || activityAttributes.user.email, activityAttributes.content)
 
       @setPaginationData(activityAttributes.channel_id)

--- a/app/assets/javascripts/backbone/plugins/music_player.js.coffee
+++ b/app/assets/javascripts/backbone/plugins/music_player.js.coffee
@@ -7,7 +7,10 @@ class Kandan.Plugins.MusicPlayer
   @stopRegex: /^&#x2F;stop/
   @resumeRegex: /^&#x2F;resume/
   @localSongData: false
-
+  @sounds: {
+    channel: 'ding.wav'
+    attention: 'gong.mp3'
+  }
 
   @playTemplate:   _.template('<strong><a class="audio-play">playing</a> <a target="_blank" href="<%- url %>"><%- url %></a></strong>')
   @stopTemplate:   _.template('<strong><a class="audio-play">stopping</a> the music.')
@@ -170,8 +173,9 @@ class Kandan.Plugins.MusicPlayer
     if @audioChannel(channelId)?
       @unmute(channelId)
 
-  @playAudioNotice: ->
-    url    = @localFileUrl('ding.wav')
+  @playAudioNotice: (type)->
+    sound  = @sounds[type] || 'ding.wav'
+    url    = @localFileUrl(sound)
     player = $('.audio_private')[0]
     player.setAttribute('src', url)
     player.play()

--- a/app/assets/javascripts/backbone/plugins/notifications.js.coffee
+++ b/app/assets/javascripts/backbone/plugins/notifications.js.coffee
@@ -76,7 +76,7 @@ class Kandan.Plugins.Notifications
   @onPopupNotificationsEnabled: ()->
     if @webkitNotificationsEnabled()
       @enablePopupNotifications()
-    
+
     return
 
   # If you are wondering why the kandan icon is not displayed on OS X this is the reason:
@@ -108,7 +108,7 @@ class Kandan.Plugins.Notifications
     @sound_notifications_enabled = true
     $(".sound-notifications .enable-sound-notifications").remove()
     $(".notification.sound-notifications").append(@disable_sound_notifications_template())
-    
+
     return
 
   @disableSoundNotifications: ()->
@@ -118,7 +118,9 @@ class Kandan.Plugins.Notifications
     $(".notification.sound-notifications").append(@enable_sound_notifications_template())
     return
 
-  @playAudioNotification: ()->
-    if @sound_notifications_enabled
-      Kandan.Plugins.MusicPlayer.playAudioNotice()
+  @playAudioNotification: (type)->
+    if @sound_notifications_enabled and not @isPlaying
+      @isPlaying = true
+      setTimeout (=> @isPlaying = false), 1000
+      Kandan.Plugins.MusicPlayer.playAudioNotice(type)
     return

--- a/app/assets/javascripts/backbone/views/show_activity.js.coffee
+++ b/app/assets/javascripts/backbone/views/show_activity.js.coffee
@@ -26,6 +26,7 @@ class Kandan.Views.ShowActivity extends Backbone.View
       
       if user_mention_regex.test(@compiledTemplate) || all_mention_regex.test(@compiledTemplate)
         $(@el).addClass("mentioned_user")
+        Kandan.Plugins.Notifications?.playAudioNotification('attention')
 
     if activity.id == undefined
       $(@el).attr("id", "activity-c#{activity.cid}")


### PR DESCRIPTION
This PR causes @mentions of the current user to play the 'gong' sound instead of the usual channel sound (#133).  In addition, this 'attention' sound is always played, even when the browser has focus or the @mention is sent from a channel other than the one the user is currently looking at.
