### PR TITLE
Fluid notifications (to support Fluid, http://fluidapp.com)

### DIFF
--- a/app/assets/javascripts/backbone/kandan.js.coffee.erb
+++ b/app/assets/javascripts/backbone/kandan.js.coffee.erb
@@ -58,6 +58,7 @@ window.Kandan =
     $(window).focus(->
       Kandan.Helpers.Utils.browserTabFocused = true
       Kandan.Helpers.Utils.resetUnreadActivities()
+      Kandan.Plugins.Notifications?.resetUnreadActivities()
       $(document).attr('title', 'Kandan')
     )
 

--- a/app/assets/javascripts/backbone/plugins/notifications.js.coffee
+++ b/app/assets/javascripts/backbone/plugins/notifications.js.coffee
@@ -5,21 +5,27 @@ class Kandan.Plugins.Notifications
   @pluginNamespace: "Kandan.Plugins.Notifications"
 
   @popup_notifications_template: _.template '<div class="notification popup-notifications"></div>'
-  @enable_popup_notifications_template = _.template '<a class="btn enable-popup-notifications" href="#"><i class="icon-check-empty"></i> Notifications</a>'
-  @disable_popup_notifications_template = _.template '<a class="btn disable-popup-notifications" href="#"><i class="icon-check"></i> Notifications</a>'
+  @enable_popup_notifications_template = _.template '<a class="btn enable-popup-notifications" href="#"><i class="icon-check-empty"></i> Desktop notifications</a>'
+  @disable_popup_notifications_template = _.template '<a class="btn disable-popup-notifications" href="#"><i class="icon-check"></i> Desktop notifications</a>'
 
   @sound_notifications_template: _.template '<div class="notification sound-notifications"></div>'
   @enable_sound_notifications_template = _.template '<a class="btn enable-sound-notifications" href="#"><i class="icon-check-empty"></i> Sounds</a>'
   @disable_sound_notifications_template = _.template '<a class="btn disable-sound-notifications" href="#"><i class="icon-check"></i> Sounds</a>'
+
+  @fluid_notifications_template: _.template '<div class="notification fluid-notifications"></div>'
+  @enable_fluid_notifications_template = _.template '<a class="btn enable-fluid-notifications" href="#"><i class="icon-check-empty"></i> Fluid notifications</a>'
+  @disable_fluid_notifications_template = _.template '<a class="btn disable-fluid-notifications" href="#"><i class="icon-check"></i> Fluid notifications</a>'
 
   @render: ($el)->
     $notifications = $("<div class='notifications_list'></div>")
     $el.next().hide();
 
     @initPopupsNotificationsButtons()
+    @initFluidNotificationsButtons()
 
     $el.html($notifications)
 
+    @initFluidNotifications($notifications)
     @initWebkitNotifications($notifications)
     @initSoundNotifications($notifications)
 
@@ -36,7 +42,7 @@ class Kandan.Plugins.Notifications
     return
 
   @initWebkitNotifications: (container)->
-    if Modernizr.notification
+    if Modernizr.notification && not window.fluid
       container.append(@popup_notifications_template())
 
       if @webkitNotificationsEnabled()
@@ -79,6 +85,30 @@ class Kandan.Plugins.Notifications
 
     return
 
+  # Fluid notifications -- http://fluidapp.com
+  @initFluidNotificationsButtons: ()->
+    $(document).on 'click', '.enable-fluid-notifications', => @enableFluidNotifications()
+    $(document).on 'click', '.disable-fluid-notifications', => @disableFluidNotifications()
+    return
+
+  @initFluidNotifications: (container)->
+    if window.fluid
+      container.append(@fluid_notifications_template())
+      @enableFluidNotifications()
+    return
+
+  @enableFluidNotifications: ()->
+    @fluid_notifications_enabled = true
+    $(".fluid-notifications .enable-fluid-notifications").remove()
+    $(".notification.fluid-notifications").append(@disable_fluid_notifications_template())
+    return
+
+  @disableFluidNotifications: ()->
+    @fluid_notifications_enabled = false
+    $(".fluid-notifications .disable-fluid-notifications").remove()
+    $(".notification.fluid-notifications").append(@enable_fluid_notifications_template())
+    return
+
   # If you are wondering why the kandan icon is not displayed on OS X this is the reason:
   # If you try notifying users on MacOS Mountain Lion, using a custom notification icon, don't be surprised that the Web browser icon overrides the icon you defined.
   # Apple locked notification icons to the app icons (for instance Chrome icon).
@@ -90,7 +120,26 @@ class Kandan.Plugins.Notifications
         @cancel()
         return
 
-      notification.show();
+      notification.show()
+
+    if @fluid_notifications_enabled
+      window.fluid.showGrowlNotification {
+        title: "Kandan",
+        description: "#{sender} says:\n\n#{message}",
+        priority: 1,
+        sticky: true,
+        identifier: "kandan",
+        #onclick: callbackFunc,
+        icon: '/assets/kandanlogo.png'
+      }
+      window.fluid.dockBadge = Kandan.Helpers.Utils.unreadActivities
+      window.fluid.requestUserAttention(false) # bounce once
+    return
+
+  @resetUnreadActivities: ()->
+    if @fluid_notifications_enabled
+      window.fluid.dockBadge = null
+    return
 
   # HTML 5 sounds
   @initSoundNotifications: ($container)->


### PR DESCRIPTION
This PR contains additions to the Notifications plugin in order to support the custom notification system provided by Fluid.  Desktop notifications do not work within Fluid, so are not enabled/displayed.  Fluid notifications do not work in browsers so are not enabled/displayed.

This includes:
- Growl notification integration (as an alternative to desktop notifications)
- Unread message count as badge on application icon in Dock
- Bounce for attention on incoming message

Feedback and suggestions for improvements welcomed - this was very much written as an enhancement to support users in my organisation, but I thought it was worthwhile offering up the functionality to the community too!
