### PR TITLE
Confine disconnect/connect activities to primary channel (Fixes #135).

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -15,18 +15,16 @@ class Channel < ActiveRecord::Base
   end
 
   class << self
+    def primary
+      self.find(1)
+    end
+
     def user_connect(user)
-      Channel.all.each do |channel|
-        activity = channel.activities.build(:user_id => user.id, :action => "connect")
-        activity.save
-      end
+      activity = Channel.primary.activities.create!(:user_id => user.id, :action => "connect")
     end
 
     def user_disconnect(user)
-      Channel.all.each do |channel|
-        activity = channel.activities.build(:user_id => user.id, :action => "disconnect")
-        activity.save
-      end
+      activity = Channel.primary.activities.create!(:user_id => user.id, :action => "disconnect")
     end
   end
 end


### PR DESCRIPTION
Activities for connect/disconnect are now only created against the primary channel (id=1), fixing #135, scenario [1].
