### PR TITLE
Handle channel creation across clients (Fixes #170)

### DIFF
--- a/app/assets/javascripts/backbone/broadcasters/faye.js.coffee
+++ b/app/assets/javascripts/backbone/broadcasters/faye.js.coffee
@@ -36,6 +36,7 @@ class Kandan.Broadcasters.FayeBroadcaster
 
   processEventsForChannel: (eventName, data)->
     Kandan.Helpers.Channels.deleteChannelById(data.entity.id) if eventName == "delete"
+    Kandan.Helpers.Channels.createChannelIfNotExists(channel: data.entity, channel_id: data.entity.id) if eventName == "create"
 
     # TODO this has to be implemented
     Kandan.Helpers.Channels.renameChannelById(data.entity.id, data.entity.name) if data.eventName == "update"

--- a/app/assets/javascripts/backbone/views/channel_tabs.js.coffee
+++ b/app/assets/javascripts/backbone/views/channel_tabs.js.coffee
@@ -30,9 +30,6 @@ class Kandan.Views.ChannelTabs extends Backbone.View
     if channelName
       channel = new Kandan.Models.Channel({name: channelName})
       channel.save({}, {
-        success: (model)->
-          Kandan.Helpers.Channels.createChannelArea(model)
-
         error: (model, response)->
           _.each(JSON.parse(response.responseText), alert);
       })


### PR DESCRIPTION
This PR causes the app to pay attention to channel create activities, and removes the channel tab creation code path from the client app in favour of waiting for the server to instruct the client to do it, fixing #170.

Note: this PR requires the channel creation observation included in #168 to operate correctly, do not merge until #168 has been merge!
