### PR TITLE
Lock ruby version to 1.9.3.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '1.9.3'
+
 # Core gems
 gem 'rails', '3.2.12'
 
@@ -27,7 +29,7 @@ group :assets do
   gem 'sass-rails'
   gem 'coffee-rails'
   gem 'bourbon', '~> 1.4.0'
-  gem 'execjs'   
+  gem 'execjs'
   gem 'eco'
   gem 'uglifier'
   gem 'bootstrap-sass', '~> 2.3.0.1'
@@ -55,7 +57,7 @@ group :test do
   gem 'simplecov', :require => false
 end
 
-group :development, :test do  
+group :development, :test do
   gem 'sqlite3'
   gem 'guard'
   gem 'guard-rspec'


### PR DESCRIPTION
Because of https://github.com/kandanapp/kandan-count/blob/master/kandan-count.gemspec#L16

Also, When I push to Heroku:

``` bash
       Gem::InstallError: kandan-count requires Ruby version >= 1.9.3.
       An error occurred while installing kandan-count (1.1.0), and Bundler cannot continue.
       Make sure that `gem install kandan-count -v '1.1.0'` succeeds before bundling.
 !
 !     Failed to install gems via Bundler.
 !
 !     Heroku push rejected, failed to compile Ruby/rails app
```
