### PR TITLE
Remove use of obsolete border-radius mixins (fixes #192).

### DIFF
--- a/app/assets/stylesheets/_activity.sass
+++ b/app/assets/stylesheets/_activity.sass
@@ -25,7 +25,7 @@
       .image-preview, .youtube-preview
         a
           width: 100%
-        +border-radius(4px)
+        border-radius: 4px
         +box-shadow(0px 1px 5px 0px #cccccc)
         padding: 10px
         background: #F3F8F9
@@ -63,7 +63,7 @@
   font-size: 11px
   position: absolute
   right: 0px
-  +border-radius(4px)
+  border-radius: 4px
   padding: 4px
   background: #F3F8F9
   color: #BDC6CA

--- a/app/assets/stylesheets/_base.sass
+++ b/app/assets/stylesheets/_base.sass
@@ -46,7 +46,7 @@ cite
 .user_menu
   background-color: $header-bg-1
   +background-image(linear-gradient($header-bg-1, $header-bg-2))
-  +border-radius(4px)
+  border-radius: 4px
   position: fixed
   right: 0px
   display: none

--- a/app/assets/stylesheets/_chat_area.sass
+++ b/app/assets/stylesheets/_chat_area.sass
@@ -5,7 +5,7 @@
 
 .ui-widget-header
   background: transparent !important
-  +border-radius(0px)
+  border-radius: 0px
   border: none
   .ui-state-active
     background: $active-tab-bg
@@ -61,7 +61,7 @@ html body .ui-tabs .ui-tabs-nav li
     &:hover
       background-position-x: -70px
 .ui-tabs
-  +border-radius(0px)
+  border-radius: 0px
   padding: 0px
   margin-top: 0px
   border: none
@@ -93,7 +93,7 @@ html body .ui-tabs .ui-tabs-nav li
   height: 100%
 
 .ui-corner-all .ui-corner-bottom, .ui-corner-bottom, .ui-corner-left, .ui-corner-right, .ui-corner-bl, .ui-corner-br
-  +border-radius(none)
+  border-radius: none
 
 .ui-state-default
   font-size: 14px
@@ -105,7 +105,8 @@ html body .ui-tabs .ui-tabs-nav li
 
 .paginated-activities, #head-mask
   +box-shadow(5px 0px 5px -3px #cccccc, -5px 0px 5px -3px #cccccc, 5px 10px 5px -3px #cccccc, -5px 10px 5px -3px #cccccc)
-  +border-top-radius(4px)
+  border-top-left-radius: 4px
+  border-top-right-radius: 4px
   float: left
   width: 100%
   background: #FFF
@@ -153,7 +154,8 @@ html body #app_body .main-area #head-mask
 /*   padding: 0px !important
 
 .chatbox
-  +border-bottom-radius(4px)
+  border-bottom-left-radius: 4px
+  border-bottom-right-radius: 4px
   +box-shadow(5px 0px 5px -3px #cccccc, -5px 0px 5px -3px #cccccc, 0px 5px 5px 0px #cccccc)
   float: left
   border-top: 1px solid #f5f8f9
@@ -165,8 +167,8 @@ html body #app_body .main-area #head-mask
   background: #e6edef
   z-index: 600
   textarea
-    +border-top-left-radius(4px)
-    +border-bottom-left-radius(4px)
+    border-top-left-radius: 4px
+    border-bottom-left-radius: 4px
     border: 1px solid #AEB9BD
     width: 92%
     padding: 0px
@@ -175,8 +177,8 @@ html body #app_body .main-area #head-mask
     resize: none
   button
     +background-image(linear-gradient(#c8ecf6, #9fdff4))
-    +border-top-right-radius(4px)
-    +border-bottom-right-radius(4px)
+    border-top-right-radius: 4px
+    border-bottom-right-radius: 4px
     position: relative
     left: -5px
     border: 1px solid #AEB9BD

--- a/app/assets/stylesheets/_sidebar.sass
+++ b/app/assets/stylesheets/_sidebar.sass
@@ -22,8 +22,10 @@
   .widget
     margin-bottom: 20px
     border: 1px solid #D0D5D8
-    +border-top-radius(4px)
-    +border-bottom-radius(7px)
+    border-top-left-radius: 4px
+    border-top-right-radius: 4px
+    border-bottom-left-radius: 7px
+    border-bottom-right-radius: 7px
     background: #F3F8F9
     float: left
     width: 100%
@@ -31,8 +33,8 @@
 
 .widget_header
   +background-image(linear-gradient($widget-title-bg-1, $widget-title-bg-2))
-  +border-top-left-radius(4px)
-  +border-top-right-radius(4px)
+  border-top-left-radius: 4px
+  border-top-right-radius: 4px
   border-bottom: 1px solid #DBDFE0
   float: left
   width: 100%
@@ -53,7 +55,7 @@
   
 
 .widget_content
-  +border-bottom-radius(7px)
+  border-bottom-radius: 7px
   float: left
   width: 100%
   clear: both
@@ -62,7 +64,7 @@
   font-size: 13px
 
 .widget_action_bar
-  +border-bottom-radius(7px)
+  border-bottom-radius: 7px
   font-size: 13px
   text-align: center
   line-height: 40px
@@ -85,7 +87,7 @@
   border-bottom: none
   height: 100%
   input
-    +border-radius(20px)
+    border-radius: 20px
     background: $search-bg url(image_path('search_icon.png')) no-repeat
     +box-shadow(inset 0px 7px 6px -5px #3a4547, 2px 7px 7px -6px #7f8587)
     background-position: 95% center


### PR DESCRIPTION
Bourbon has obsoleted the border-radius mixins now that modern browsers all support the non-namespaced version.  This PR contains a patch that removes their use from the stylesheets, fixing #192.
