### PR TITLE
Fixed faye host bug for production

### DIFF
--- a/app/assets/javascripts/backbone/broadcasters/faye.js.coffee.erb
+++ b/app/assets/javascripts/backbone/broadcasters/faye.js.coffee.erb
@@ -1,11 +1,7 @@
 class Kandan.Broadcasters.FayeBroadcaster
 
   constructor: ()->
-    @fayeClient = new Faye.Client("http://<%= ActionMailer::Base.default_url_options[:host] %>/remote/faye")
-
-    <% if Rails.env == "test" %>
-    @fayeClient.setHeader('Access-Control-Allow-Origin', '*');
-    <% end %>
+    @fayeClient = new Faye.Client("<%= ENV['FULL_HOST'] %>/remote/faye")
 
     @fayeClient.disable('websocket')
     authExtension = {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,6 +39,5 @@ Kandan::Application.configure do
   config.logger.level = Logger.const_get(
     ENV['LOG_LEVEL'] ? ENV['LOG_LEVEL'].upcase : 'DEBUG'
   )
-
-  config.action_mailer.default_url_options = { :host => "localhost:3000" }
+  
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,5 +35,7 @@ Kandan::Application.configure do
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 
-  config.action_mailer.default_url_options = { :host => "localhost:9292" }
+  # Variable set to be able to get faye client for test environments
+  ENV['FULL_HOST'] = "http://localhost:9292"
+
 end

--- a/lib/broadcasters/faye.rb
+++ b/lib/broadcasters/faye.rb
@@ -13,7 +13,7 @@ module Broadcasters
       end
 
       def assets
-        ["http://#{ActionMailer::Base.default_url_options[:host]}/remote/faye.js"]
+        ["#{ENV['FULL_HOST']}/remote/faye.js"]
       end
     end
   end


### PR DESCRIPTION
- Faye now uses and ENV variable only for test env.
- Removed unnecessary access-control-allow for test env
- Removed default_url_for_options for Action Mailer to avoid having to set it on production env
- Fixes #209
