### PR TITLE
Fixes MySql support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ gem 'rails', '3.2.12'
 # Database adapters
 gem 'pg'
 
+# Uncomment next line when using MySQL database
+#gem 'mysql2'
+
 # Auth gems
 gem 'devise'
 

--- a/db/migrate/20120306154555_devise_create_users.rb
+++ b/db/migrate/20120306154555_devise_create_users.rb
@@ -48,7 +48,6 @@ class DeviseCreateUsers < ActiveRecord::Migration
     end
 
     add_index :users, :email,  :unique => true
-    add_index :users, :ido_id, :unique => true
     # add_index :users, :confirmation_token,   :unique => true
     # add_index :users, :unlock_token,         :unique => true
     add_index :users, :authentication_token, :unique => true

--- a/db/migrate/20130301022941_remove_ido_id_from_users.rb
+++ b/db/migrate/20130301022941_remove_ido_id_from_users.rb
@@ -1,11 +1,9 @@
 class RemoveIdoIdFromUsers < ActiveRecord::Migration
   def up
-  	remove_index :users, :ido_id
   	remove_column :users, :ido_id
   end
 
   def down
   	add_column :users, :ido_id, :text
-  	add_index :users, :ido_id, :unique => true
   end
 end


### PR DESCRIPTION
- Removed index on migration because the index is removed on the later migration anyways and MySQL doesn't like indexes on text columns.
- Fixes #207
- This was tested using MySQL on OS X
