### PR TITLE
Fixed Version Number in the /about page

### DIFF
--- a/config/initializers/git_revision.rb
+++ b/config/initializers/git_revision.rb
@@ -1,4 +1,4 @@
 module AppName
-  VERSION = 'Version 1.1'		
+  VERSION = 'Version 1.2'		
   REVISION = `git log --pretty=format:'%h' -n 1`
 end


### PR DESCRIPTION
Actually this pull request is pretty useless, but can help to make clear which version of the software has been installed.
