### PR TITLE
Fixes 232 Emojist only show once per line, fix indentation

### DIFF
--- a/app/assets/javascripts/backbone/plugins/emoticons.js.coffee
+++ b/app/assets/javascripts/backbone/plugins/emoticons.js.coffee
@@ -909,10 +909,11 @@ class Kandan.Plugins.Emoticons
     Kandan.Modifiers.register @options.regex, (message, activity) =>
       matches = message.match(@options.regex)
       for match in _.unique(matches)
-        match = match.trim();
+        match = match.trim()
         emoticon = @emoticons[match]
-        
+
         if emoticon
-            message = message.replace(match, @options.template(emoticon)) 
+          # replace all matches
+          message = message.split(match).join(@options.template(emoticon))
 
       return message

--- a/app/assets/javascripts/layout.js.coffee
+++ b/app/assets/javascripts/layout.js.coffee
@@ -1,8 +1,8 @@
 $(document).ready ->
 	$(".user_menu_link").click (e)->
-      e.preventDefault()
-      $(".user_menu").toggle()
-      false
+    e.preventDefault()
+    $(".user_menu").toggle()
+    false
 
-  	$(".user_menu a").click (e)->
-      $(".user_menu").toggle()
+  $(".user_menu a").click (e)->
+    $(".user_menu").toggle()


### PR DESCRIPTION
Fixes #232 
Can't wait to fix it.
Javascript don't have native `string#replaceAll`.
`string.split(oldStr).join(newStr)` is the best way i found.
