### PR TITLE
Use ||= and fix spelling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   end
 
   def redirect_suspended_account
-  	# We will redirect to suspended if a user is singed in and its marked as suspended 
+  	# We will redirect to suspended if a user is signed in and its marked as suspended 
   	redirect = user_signed_in? && current_user.registration_status.suspended?
   	
   	redirect_to suspended_path if redirect

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,7 +36,7 @@ Kandan::Application.configure do
   config.active_support.deprecation = :stderr
 
   # Variable set to be able to get faye client for test environments
-  ENV['KANDAN_FAYE_PORT'] = "9292" unless ENV['KANDAN_FAYE_PORT']
-  ENV['KANDAN_FAYE_URL'] = "http://localhost:#{ENV['KANDAN_FAYE_PORT']}" unless ENV['KANDAN_FAYE_URL']
+  ENV['KANDAN_FAYE_PORT'] ||= "9292"
+  ENV['KANDAN_FAYE_URL'] ||= "http://localhost:#{ENV['KANDAN_FAYE_PORT']}"
 
 end


### PR DESCRIPTION
Change test.rb to use ||= for faye ENV stuff and fix a spelling error
