### PR TITLE
Chat and channel boxes' styles are "broken"

### DIFF
--- a/app/assets/stylesheets/_chat_area.sass
+++ b/app/assets/stylesheets/_chat_area.sass
@@ -38,11 +38,11 @@ html body .ui-tabs .ui-tabs-nav li
       background: url(image_path('tabs/tab-inactive-middle.png')) repeat-x
       float: left
       padding-top: 7px
-      color: #585d5f !important	
-      position: relative	 
+      color: #585d5f !important
+      position: relative
       .close_channel
         cursor: pointer
-        padding-left: 5px	
+        padding-left: 5px
     .tab_right
       background: url(image_path('tabs/tab-inactive-right.png')) no-repeat
       float: right
@@ -77,7 +77,7 @@ html body .ui-tabs .ui-tabs-nav li
       font-size: 14px
     .ui-state-default
       border: none
-      color: #7f8587	
+      color: #7f8587
       background: transparent !important
       a
         padding: 0px !important
@@ -164,7 +164,7 @@ html body #app_body .main-area #head-mask
   float: left
   border-top: 1px solid #f5f8f9
   padding: 10px 0px 10px 10px
-  width: 77.2%
+  width: 76.9%
   position: fixed
   bottom: 0px
   margin-bottom: 20px
@@ -212,4 +212,3 @@ html body #app_body .main-area #head-mask
 
 .channels-pane::-webkit-scrollbar
   width: 15px
-  


### PR DESCRIPTION
I have a fresh Kandan installation.
My setup is a 13" Macbook Pro running on OSX 10.8.4, Ruby 2.0.0-p195 and Rails 3.2.14.
These are the UI issues that I've found and I would like to know if anybody else is also having this:

![kandan](https://f.cloud.github.com/assets/196122/1244730/b101206e-2a8c-11e3-91f6-052569cb1608.png)
There is a gap on both sides of the screen between the shadow of the two elements, the header and the channel box (the feed/messages container). As soon as you start scrolling down you see the two shadows merging and the gap disappears but if you scroll all the way up again you'll be able to see it.

---

![kandan_and_kandan](https://f.cloud.github.com/assets/196122/1244742/1b558a9a-2a8d-11e3-918f-a567e62f8ab5.png)
There is an overflow on the chat box.

---

I have been able to reproduce these errors on:
- Chrome 29
- Safari 6.0.5
- Opera 15
- Firefox 24
- Firefox Nightly
