### PR TITLE
Fixing the regex in mentions.coffee

### DIFF
--- a/app/assets/javascripts/backbone/plugins/mentions.coffee
+++ b/app/assets/javascripts/backbone/plugins/mentions.coffee
@@ -4,7 +4,7 @@ class Kandan.Plugins.Mentions
   @options:
     regex: /(^|\s)@\S*/gm
 
-    template: _.template '''<span class="mention"><%= mention %></span>'''
+    template: _.template '''<span class="mention"><%= mention.trim() %></span>'''
 
   @init: ()->
     Kandan.Data.ActiveUsers.registerCallback "change", (data)=>


### PR DESCRIPTION
Thank you very much for kandan, it's excellent. I've been messing around with it today, and it bugged me how the mentions plugin highlighted the middle of email addresses:

![before](https://f.cloud.github.com/assets/578458/1799066/810d04a8-6b83-11e3-8c98-249a79d719f8.png)

I changed the regex in mentions.coffee to fix this, and updated the comments a little bit too.

![after](https://f.cloud.github.com/assets/578458/1799067/acfbddfa-6b83-11e3-98e0-e6114ee33d3d.png)
![after2](https://f.cloud.github.com/assets/578458/1799068/ad15cada-6b83-11e3-9a01-2d9e9ed8f098.png)

I've never worked with ruby, rails, or coffeescript before, so I'm not sure if I've done everything I need to. I kept running `rake assets:clean` and couldn't find any tests that would need updating.

If there's anything else I need to do let me know!
