### PR TITLE
Issues with S3 and new version of Paperclip validations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'paperclip'
 gem 'remotipart'
 gem 'jquery-rails'
 gem 'enumerize'
+gem 'arel'
+gem 'tzinfo'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,11 +20,6 @@ GEM
     activerecord (3.2.16)
       activemodel (= 3.2.16)
       activesupport (= 3.2.16)
-    activerecord (3.2.14)
-      activemodel (= 3.2.14)
-      activesupport (= 3.2.14)
-      arel (~> 3.0.2)
-      tzinfo (~> 0.3.29)
     activeresource (3.2.16)
       activemodel (= 3.2.16)
       activesupport (= 3.2.16)
@@ -32,7 +27,7 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     addressable (2.3.5)
-    arel (3.0.3)
+    arel (4.0.2)
     atomic (1.1.14)
     awesome_print (1.2.0)
     aws-sdk (1.34.0)
@@ -63,8 +58,6 @@ GEM
     celluloid-io (0.15.0)
       celluloid (>= 0.15.0)
       nio4r (>= 0.5.0)
-    childprocess (0.4.0)
-      ffi (~> 1.0, >= 1.0.11)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cliver (0.3.2)
@@ -257,17 +250,11 @@ GEM
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
-    rubyzip (1.1.0)
     sass (3.2.14)
     sass-rails (3.2.6)
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    selenium-webdriver (2.39.0)
-      childprocess (>= 0.2.5)
-      multi_json (~> 1.0)
-      rubyzip (~> 1.0)
-      websocket (~> 1.0.4)
     shoulda-matchers (2.5.0)
       activesupport (>= 3.0.0)
     simplecov (0.8.2)
@@ -297,14 +284,14 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.38)
+    tzinfo (1.1.0)
+      thread_safe (~> 0.1)
     uglifier (2.4.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     uuidtools (2.1.4)
     warden (1.2.3)
       rack (>= 1.0)
-    websocket (1.0.7)
     websocket-driver (0.3.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -313,6 +300,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  arel
   awesome_print
   aws-sdk
   better_errors
@@ -354,4 +342,5 @@ DEPENDENCIES
   simplecov
   sqlite3
   thin
+  tzinfo
   uglifier

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -26,7 +26,7 @@ class AttachmentsController < ApplicationController
     @attachment.file = params[:file]
 
     respond_to do |format|
-      if @attachment.save
+      if @attachment.save( validate: false )
         format.json { render json: @attachment, status: :created }
       else
         format.json { render json: @attachment.errors, status: :unprocessable_entity }

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,7 +1,7 @@
 class Attachment < ActiveRecord::Base
   belongs_to :channel
   belongs_to :user
-  
+
   if ENV['S3_BUCKET']
     has_attached_file(:file, {
       :storage         => :s3,
@@ -14,6 +14,7 @@ class Attachment < ActiveRecord::Base
       :url    => "/:attachment/:id/:style/:basename.:extension",
       :path   => "#{ENV['S3_PREFIX']}/:attachment/:id/:style/:basename.:extension"
     })
+    validates_attachment_content_type :file, :content_type=>"*"  #This doesn't do anything but it is required by Paperclip 4+
   else
     has_attached_file :file
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,3 +3,10 @@
 
 en:
   hello: "Hello world"
+  activerecord:
+    errors:
+      models:
+        attachment:
+          attributes:
+            file:
+              spoofed_media_type: "Media Type Spoofed"


### PR DESCRIPTION
So I tried to deploy this last night to heroku and use S3 for storage but I was blocked by the Missing validation due to the upgrade to Paperclip ~4.1.0 which strongly restricts you to having to include explicit content type and file extension information to your application.

For the moment I have this patch with includes the validation for S3 and then skips validation so you can still upload whatever you want. The alternative is to rollback the Paperclip gem to ~3.5.4 which I am currently doing in production.

Commit Info
#### Not checking validations on attachments save for paperclip 4.0
- In the new version of paperclip content spoofing validation interferes with uploading whatever you want
- Additionally added I18n translation and call to required paperclip validation
- Adding arel and tzinfo because they were expected to resolve some dependency
