### PR TITLE
activerecord depends on older versions of tzinfo and arel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,6 @@ gem 'paperclip'
 gem 'remotipart'
 gem 'jquery-rails'
 gem 'enumerize'
-gem 'arel'
-gem 'tzinfo'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,8 @@ GEM
     activerecord (3.2.16)
       activemodel (= 3.2.16)
       activesupport (= 3.2.16)
+      arel (~> 3.0.2)
+      tzinfo (~> 0.3.29)
     activeresource (3.2.16)
       activemodel (= 3.2.16)
       activesupport (= 3.2.16)
@@ -27,7 +29,7 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     addressable (2.3.5)
-    arel (4.0.2)
+    arel (3.0.3)
     atomic (1.1.14)
     awesome_print (1.2.0)
     aws-sdk (1.34.0)
@@ -284,8 +286,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (1.1.0)
-      thread_safe (~> 0.1)
+    tzinfo (0.3.38)
     uglifier (2.4.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -300,7 +301,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  arel
   awesome_print
   aws-sdk
   better_errors
@@ -342,5 +342,4 @@ DEPENDENCIES
   simplecov
   sqlite3
   thin
-  tzinfo
   uglifier


### PR DESCRIPTION
activerecord needs older versions of tzinfo and arel, which are locked to newer versions in the master Gemfile. This PR removes these declarations (since the app itself doesn't seem to depend on those gems) and leaves bundler to resolve the dependencies transitively.
