### PR TITLE
create a vagrant environment, closes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ DS_Store
 public/system/*
 
 vendor/bundle
+
+.vagrant
+puppet/modules
+puppet/.tmp

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,42 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.librarian_puppet.puppetfile_dir = "puppet"
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "precise64"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.network :forwarded_port, guest: 3000, host: 3000
+  config.vm.network :forwarded_port, guest: 5432, host: 5432
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Bootstrap first!
+  config.vm.provision "shell", inline: "sudo apt-get update"
+
+  # Enable provisioning with Puppet stand alone.  Puppet manifests
+  # are contained in a directory path relative to this Vagrantfile.
+  # You will need to create the manifests directory and a manifest in
+  # the file precise64.pp in the manifests_path directory.
+  config.vm.provision :puppet do |puppet|
+    puppet.module_path = "puppet/modules"
+    puppet.manifests_path = "puppet/manifests"
+    puppet.manifest_file  = "site.pp"
+  end
+
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,11 +1,13 @@
 # Postgres settings
 # #################
-# development:
-#   adapter: postgresql
-#   host: localhost
-#   database: kandan_development
-#   pool: 5
-#   timeout: 5000
+production:
+  adapter: postgresql
+  host: localhost
+  username: postgres
+  password: postgres
+  database: kandan_production
+  pool: 5
+  timeout: 5000
 
 development:
   adapter: sqlite3

--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -1,0 +1,5 @@
+forge "http://forge.puppetlabs.com"
+
+mod "alup/rbenv", :git => "git@github.com:cleblanc87/puppet-rbenv.git"
+
+mod "puppetlabs/postgresql"

--- a/puppet/Puppetfile.lock
+++ b/puppet/Puppetfile.lock
@@ -1,0 +1,26 @@
+FORGE
+  remote: http://forge.puppetlabs.com
+  specs:
+    puppetlabs/apt (1.4.1)
+      puppetlabs/stdlib (>= 2.2.1)
+    puppetlabs/concat (1.1.0-rc1)
+      puppetlabs/stdlib (>= 3.0.0)
+    puppetlabs/firewall (1.0.0)
+    puppetlabs/postgresql (3.3.0)
+      puppetlabs/apt (< 2.0.0, >= 1.1.0)
+      puppetlabs/concat (< 2.0.0, >= 1.0.0)
+      puppetlabs/firewall (>= 0.0.4)
+      puppetlabs/stdlib (< 5.0.0, >= 3.2.0)
+    puppetlabs/stdlib (4.1.0)
+
+GIT
+  remote: git@github.com:cleblanc87/puppet-rbenv.git
+  ref: master
+  sha: 4193edb0e2832d4389bd24bbe9f52e8c4dc4d177
+  specs:
+    alup/rbenv (1.2.0)
+
+DEPENDENCIES
+  alup/rbenv (>= 0)
+  puppetlabs/postgresql (>= 0)
+

--- a/puppet/manifests/site.pp
+++ b/puppet/manifests/site.pp
@@ -1,0 +1,45 @@
+Exec { path => ["/home/vagrant/.rbenv/bin/", "/home/vagrant/.rbenv/shims/", "/bin/", "/sbin/" , "/usr/bin/", "/usr/sbin/" ] }
+
+rbenv::install { "vagrant": group => 'vagrant'}
+rbenv::compile { "2.0.0-p0": user => "vagrant", global => true}
+
+class { 'postgresql::globals':
+  encoding => 'UTF8',
+  locale   => 'en_NG',
+}->
+class { 'postgresql::server':
+  encoding => 'UTF8',
+  listen_addresses => '*',
+  ip_mask_deny_postgres_user => '0.0.0.0/32',
+  ip_mask_allow_all_users => '0.0.0.0/0',
+  postgres_password => 'postgres',
+}
+postgresql::server::db { 'kandan_production':
+  encoding => 'UTF8',
+  user => 'postgres',
+  password => 'postgres',
+}
+package { 'libpq-dev': }
+
+package { 'libsqlite3-dev': }
+
+exec{"bundle_install":
+  command => "bundle install",
+  timeout => 0,
+  cwd => '/vagrant',
+  require => [Rbenvgem["vagrant/2.0.0-p0/bundler/present"], Rbenv::Install["vagrant"], Class["postgresql::server"]]
+}
+
+exec{"create_kandan_db":
+  command => 'bundle exec rake db:migrate kandan:bootstrap',
+  cwd => '/vagrant',
+  environment => 'RAILS_ENV=production',
+  require => Exec['bundle_install']
+}
+
+exec{"start_kandan":
+  command => 'bundle exec rails s -d',
+  cwd => '/vagrant',
+  environment => 'RAILS_ENV=production',
+  require => Exec['create_kandan_db']
+}


### PR DESCRIPTION
For discussion...

Needs docs, requires the https://github.com/mhahn/vagrant-librarian-puppet plugin.

running `vagrant up` starts the application on localhost:3000 in production.

The site.pp manifest within should be refactored to a puppet module.

Thoughts?
