### PR TITLE
A more SSL friendly Kandan.

### DIFF
--- a/app/assets/javascripts/backbone/plugins/music_player.js.coffee
+++ b/app/assets/javascripts/backbone/plugins/music_player.js.coffee
@@ -113,7 +113,7 @@ class Kandan.Plugins.MusicPlayer
     Kandan.Store.get @pluginId, callbacks
 
   @localFileUrl: (fileName) ->
-    "http://#{ window.location.hostname }:#{ window.location.port }/sounds/#{ fileName }"
+    "//#{ window.location.hostname }:#{ window.location.port }/sounds/#{ fileName }"
 
   @localSounds: (name) ->
     sounds = {

--- a/app/assets/javascripts/backbone/plugins/vimeo_embed.js.coffee
+++ b/app/assets/javascripts/backbone/plugins/vimeo_embed.js.coffee
@@ -2,10 +2,10 @@ class Kandan.Plugins.VimeoEmbed
 
   @options:
     regex: /^http[s]?:&#x2F;&#x2F;(w{3}.)?vimeo.com&#x2F;(\d+)/i
-    
+
     template: _.template '''
       <div class="vimeo-preview">
-        <iframe src="http://player.vimeo.com/video/<%= videoId %>" width="500" height="281" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
+        <iframe src="//player.vimeo.com/video/<%= videoId %>" width="500" height="281" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
         <div class="name"><%= subtitle %></div>
       </div>
     '''
@@ -24,7 +24,7 @@ class Kandan.Plugins.VimeoEmbed
       videoUrl = message.split(" ")[0]
 
       videoId = message.match(@options.regex)[2]
-      
+
       subtitle = null
       subtitle = "Vimeo: #{comment}" if comment? and comment.length > 0
       subtitle ||= videoUrl

--- a/app/assets/javascripts/backbone/plugins/youtube_embed.js.coffee
+++ b/app/assets/javascripts/backbone/plugins/youtube_embed.js.coffee
@@ -7,7 +7,7 @@ class Kandan.Plugins.YouTubeEmbed
     template: _.template '''
       <div class="youtube-preview">
             <iframe width="560" height="315"
-                    src="http://www.youtube.com/embed/<%= videoId %>"
+                    src="//www.youtube.com/embed/<%= videoId %>"
                     frameborder="0" allowfullscreen>
             </iframe>
         <div class="name"><%= subtitle %></div>

--- a/config/kandan_settings.yml
+++ b/config/kandan_settings.yml
@@ -14,7 +14,7 @@
 
 :public_site: true
 
-:avatar_url: http://gravatar.com/avatar/%{hash}?s=%{size}&d=%{fallback}
+:avatar_url: https://secure.gravatar.com/avatar/%{hash}?s=%{size}&d=%{fallback}
 :avatar_fallback: identicon
 
 :now_threshold: 3000


### PR DESCRIPTION
The MusicPlayer, VimeoEmbed and YouTubeEmbed plugins are now protocol
agnostic and will work with SSL/non-SSL Kandan install.

The standard Gravatar address in kandan_settings.yml now defaults to the
SSL Gravatar address.

Closes #322.
