### PR TITLE
DEPLOY.md needs a few more tweaks before it can be setup on Heroku

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -118,6 +118,25 @@ You'll need to have the [heroku CLI](https://github.com/heroku/heroku) installed
     heroku run rake db:migrate kandan:bootstrap && heroku open
     echo "Done, go forth and chat!"
     # Not too bad
+
+If you want emails to work (forgotten passwords, etc), you'll also need to add a Heroku email add-on to your app. For example, to add SendGrid:
+    
+    heroku addons:add sendgrid:starter
+
+After you add an email provider to your Heroku app, you'll also need to setup your production.rb file to look similar to this (using SendGrid again as an example):
+
+    config.action_mailer.default_url_options = { :host => "yourapp.herokuapp.com" } (Or whatever connected to your heroku app)
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.perform_deliveries = true
+
+    config.action_mailer.smtp_settings = {
+        address: "smtp.sendgrid.net",
+        port: 25,
+        domain: "example.com",
+        authentication: "plain",
+        user_name: ENV["SENDGRID_USERNAME"],
+        password: ENV["SENDGRID_PASSWORD"]
+    }
     
 ### Integrate Kandan on Heroku with your Amazon S3_BUCKET ( [Heroku article on AWS S3 to store static assets and file uploads](https://devcenter.heroku.com/articles/s3) ). Run the following line, replacing the the global variable values with your own:
 


### PR DESCRIPTION
When I was deploying this app, I found out that there were a few pieces missing before I could get everything up and running. The main thing was that emails were not being sent out, and this happens even on the Kandan demo Heroku app:

![screen shot 2014-04-02 at 2 14 42 am](https://cloud.githubusercontent.com/assets/463175/2587905/295ebc84-ba2e-11e3-8bb2-b1464207cc94.png)

To fix these issues, three things need to happen:
- production.rb needs to have a config setting for config.action_mailer.default_url_options = { :host => "whatever" }
- the Heroku app needs a mail service add-on for it (I use Sendgrid in my example)
- Those email add-on options need to be added to production.rb for emails to go out.
