### PR TITLE
no checking validation of an attachmnet file for non S3 env

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -17,6 +17,7 @@ class Attachment < ActiveRecord::Base
     validates_attachment_content_type :file, :content_type=>"*"  #This doesn't do anything but it is required by Paperclip 4+
   else
     has_attached_file :file
+    do_not_validate_attachment_file_type :file
   end
   
   attr_accessible :file


### PR DESCRIPTION
No checking validation of an attachment file for non S3 env.
#313 added no validation for S3 env.

this also add no validation of attachment file for non S3 env.
