### PR TITLE
Added ability to authenticate by authenticity token, needed for compatibility with hubot.

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,4 +1,5 @@
 class ActivitiesController < ApplicationController
+  before_filter :authenticate_user_from_token!, :only => :create
   before_filter :authenticate_user!
 
   def index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,4 +18,21 @@ class ApplicationController < ActionController::Base
   	redirect_to suspended_path if redirect
   end
 
+  private
+
+  # For this example, we are simply using token authentication
+  # via parameters. However, anyone could use Rails's token
+  # authentication features to get the token from a header.
+  def authenticate_user_from_token!
+    user_token = params[:auth_token].presence
+    user       = user_token && User.find_by_authentication_token(user_token.to_s)
+
+    if user
+      # Notice we are passing store false, so the user is not
+      # actually stored in the session and a token is needed
+      # for every request. If you want the token to work as a
+      # sign in token, you can simply remove store: false.
+      sign_in user, store: false
+    end
+  end
 end


### PR DESCRIPTION
Hubot couldn't actually create activities in Kandan due to the removal of authenticity-token based validation from Devise in the Kandan app. This isn't ideal, but it works and will allow the Kandan Hubot to post activities in response to commands.
