### PR TITLE
Fixed issue with gravatar_url for user that no longer exists.

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -27,6 +27,8 @@ class ActivitiesController < ApplicationController
     # NOTE if the action is accessed then there's definitely activities, so skip check for #first to be nil
     more_activities = first_activity_id < (activities.last.try(:id).presence || 1)
 
+    activities.each { |a| a.user ||= User.deleted_user }
+
     respond_to do |format|
       format.json { render :text => {:activities => activities.reverse, :more_activities => more_activities }.to_json(:include => :user) }
     end


### PR DESCRIPTION
There was a bug with the app where if the page was loaded and the user scrolled up, causing the app to auto-load earlier activities, if any of those earlier activities were created by users that are now deleted, it'd fail to load those activities into the page. The loading indicator would just stay at the top of the page indefinitely and nothing more could be scrolled/loaded.
