### PR TITLE
Specify ruby version 1.9.3 in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+ruby '1.9.3'
+
 source 'https://rubygems.org'
 
 # Core gems


### PR DESCRIPTION
As ruby 1.9 is [required for kandan](https://github.com/kandanapp/kandan/blob/master/DEPLOY.md#requirements).
Specifying it in Gemfile is requiered for Heroku deployment [since ruby 2 is default](https://blog.heroku.com/archives/2013/6/17/ruby-2-default-new-aps).
