### PR TITLE
Shouldn't matter if a user is messaging from a separate tab or device...

### DIFF
--- a/app/assets/javascripts/backbone/helpers/channels.js.coffee
+++ b/app/assets/javascripts/backbone/helpers/channels.js.coffee
@@ -103,7 +103,7 @@ class Kandan.Helpers.Channels
     local = local || false
     console.log !local, !belongsToCurrentUser, !activityExists
 
-    if local || (!local && !belongsToCurrentUser && !activityExists)
+    if local || (!local && !activityExists)
       @channelActivitiesEl(activityAttributes.channel_id)
         .append(@newActivityView(activityAttributes).render().el)
 


### PR DESCRIPTION
under the same user name, chat history should always broadcast.
