### PR TITLE
Creation Initial channel

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ActiveRecord::Base
 
   before_create :mark_registration_status_depending_on_app_settings
 
-  after_create :ensure_at_least_one_admin
+  after_create :ensure_at_least_one_admin, :create_initial_channel
   after_destroy :ensure_at_least_one_admin
   
   validates :username, :presence => true, :uniqueness => true
@@ -55,6 +55,13 @@ class User < ActiveRecord::Base
       u = User.first
       u.is_admin = true
       u.save!
+    end
+  end
+  # Creates a new channel to avoid the 'no Channel id = 1' error
+  def create_initial_channel
+    if User.count == 1 && Channel.count == 0
+      c = Channel.create!(name: 'Example', user: User.first)
+      c.save!
     end
   end
 


### PR DESCRIPTION
Updated the user model with a create_initial_channel method in order to avoid application failure upon admin creation ( "cannot find channel[id] = 1")
