### PR TITLE
Added options to modifier callbacks, fixed music player playback on scroll

### DIFF
--- a/app/assets/javascripts/backbone/modifiers.js.coffee
+++ b/app/assets/javascripts/backbone/modifiers.js.coffee
@@ -7,10 +7,10 @@ class Kandan.Modifiers
   @all: ()->
     @modifiers
 
-  @process: (activity)->
+  @process: (activity, options)->
     message = activity.content
     for modifier in @modifiers
       if message.match(modifier.regex) != null
-        message = modifier.callback(message, activity)
+        message = modifier.callback(message, activity, options)
     
     return message

--- a/app/assets/javascripts/backbone/plugins/music_player.js.coffee
+++ b/app/assets/javascripts/backbone/plugins/music_player.js.coffee
@@ -71,14 +71,14 @@ class Kandan.Plugins.MusicPlayer
 
 
   @registerPlayModifier: ()->
-    Kandan.Modifiers.register @playRegex, (message, activity) =>
+    Kandan.Modifiers.register @playRegex, (message, activity, options) =>
       url = $.trim(message.substr(message.indexOf(" ") + 1));
       rawInput  = Kandan.Helpers.Utils.unescape(url)
       soundUrl  = null
       soundUrl  = @localSounds(rawInput)
       soundUrl ?= rawInput
 
-      if true and Kandan.Data.Channels.activeChannelId()?
+      if !options.silence_music and Kandan.Data.Channels.activeChannelId()?
         @playUrl(activity.channel_id, soundUrl)
       else
         console.log "Not playing stale song"

--- a/app/assets/javascripts/backbone/views/channel_pane.js.coffee
+++ b/app/assets/javascripts/backbone/views/channel_pane.js.coffee
@@ -61,7 +61,7 @@ class Kandan.Views.ChannelPane extends Backbone.View
       data: { oldest: oldest },
       success: (collection) =>
         for activity in collection.models.reverse()
-          activityView = new Kandan.Views.ShowActivity(activity: activity, silence_mentions: true)
+          activityView = new Kandan.Views.ShowActivity(activity: activity, silence_mentions: true, silence_music: true)
           $container.find(".channel-activities").prepend(activityView.render().el)
 
         if $current_top_element.length != 0

--- a/app/assets/javascripts/backbone/views/show_activity.js.coffee
+++ b/app/assets/javascripts/backbone/views/show_activity.js.coffee
@@ -10,7 +10,7 @@ class Kandan.Views.ShowActivity extends Backbone.View
 
     switch activity.action
       when "message"
-        activity.content =  Kandan.Modifiers.process(activity)
+        activity.content =  Kandan.Modifiers.process(activity, @options)
         @compiledTemplate = Kandan.Helpers.Activities.buildFromMessageTemplate activity
       when "upload"
         file_path = _.unescape(activity.content).split('?')[0].split('/')


### PR DESCRIPTION
There was a bug in the music player, which would cause audio files to play when loading previous messages as the user scrolled up. Managed to trace this to the music player modifer, which gets called on activity rendering, both when the message is created, and when the message is loaded from previous activities.

I fixed this by passing the options from `Views.ChannelPane` through to the `Views.ShowActivity`, which in turn passes options to the `Modifiers.process()` function, which in turn passes the options to the modifier callbacks as a third argument.

Then the music player modifier checks for the new `silence_music` option, which is passed when called from the `loadMoreActivities()` function.

Also, the music player modifier previously checked for `if true and Kandan.Data.Channels.activeChannelId()?` before playing the audio file. After looking through the entire git blame history of that line, apparently the `if true` part has been there since a rewrite of the plugin a ways back. It doesn't look like it's ever been functional, so I'm guessing it was just left over from debugging and they forgot to remove it before committing, and just no one has ever removed it. I.e. it was never functional in any way, so I removed that now too.
