### PR TITLE
Fixed auto-scroll to latest message when new activity appears.

### DIFF
--- a/app/assets/javascripts/backbone/helpers/channels.js.coffee
+++ b/app/assets/javascripts/backbone/helpers/channels.js.coffee
@@ -26,7 +26,7 @@ class Kandan.Helpers.Channels
       $('.channels-pane').scrollTop($('.channels-pane').prop('scrollHeight'))
 
   @currentScrollPosition: (channelId) ->
-    $('channels-pane').scrollTop()
+    $('.channels-pane').scrollTop()
 
   @channelPane: (channelId) ->
     $("#channels-#{channelId}")


### PR DESCRIPTION
Finally figured out why the message area wasn't scrolling down when a new message is received (making the user have to manually scroll down in message pane to see any new messages). It was due to a typo in the jQuery selector to get the current scroll position.

This method is called by the `@pastAutoScrollThreshold` function, which is called by `@addActivity` function to see if it should auto-scroll down to the last message after inserting a new message. This would cause `currentPosition` to be equal to `null`, causing `scrollPosition` to be `NaN`, which would result in the function returning `false`.
