### PR TITLE
Fix travis failure caused by bundle install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,11 @@ group :development do
   gem 'awesome_print'
   gem 'better_errors'
   gem 'binding_of_caller'
-  gem 'debugger'
+  if RUBY_VERSION >= '2.0.0'
+    gem 'byebug'
+  else
+    gem 'debugger'
+  end
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,9 @@ GEM
       sass (>= 3.2.0)
       thor
     builder (3.0.4)
+    byebug (3.2.0)
+      columnize (~> 0.8)
+      debugger-linecache (~> 1.2)
     cancan (1.6.10)
     capybara (2.2.1)
       mime-types (>= 1.16)
@@ -72,7 +75,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.7.0)
-    columnize (0.3.6)
+    columnize (0.8.9)
     cookiejar (0.3.2)
     coveralls (0.7.0)
       multi_json (~> 1.3)
@@ -83,12 +86,7 @@ GEM
     daemons (1.1.9)
     database_cleaner (1.2.0)
     debug_inspector (0.0.2)
-    debugger (1.6.6)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.2)
     devise (3.2.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -306,12 +304,12 @@ DEPENDENCIES
   binding_of_caller
   bootstrap-sass
   bourbon
+  byebug
   cancan
   capybara
   coffee-rails
   coveralls
   database_cleaner
-  debugger
   devise
   eco
   enumerize


### PR DESCRIPTION
Only 1.9.2 and 1.9.3 are supported in debugger gem(https://github.com/cldwalker/debugger#known-issues). In 2.0 ruby, using byebug instead.
