### PR TITLE
Lock bootstrap-sass at latest compatible version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ DS_Store
 public/system/*
 
 vendor/bundle
+
+# RubyMine config files
+.idea/

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :assets do
   gem 'execjs'
   gem 'eco'
   gem 'uglifier'
-  gem 'bootstrap-sass'
+  gem 'bootstrap-sass', '3.1.1.0'
   gem 'sass', '3.2.13'
   gem 'gemoji'
 end


### PR DESCRIPTION
Hello once again.

The latest bootstrap-sass version is not compatible with Rails 3 and causes errors about mixins that are not found which effectively prevents application from opening. The latest compatible version is 3.1.1.0 (https://github.com/twbs/bootstrap-sass#rails-32x).
