### PR TITLE
Sort user list by admin first, then by username

### DIFF
--- a/app/assets/javascripts/backbone/plugins/user_list.js.coffee
+++ b/app/assets/javascripts/backbone/plugins/user_list.js.coffee
@@ -15,7 +15,9 @@ class Kandan.Plugins.UserList
     $users = $("<ul class='user_list'></ul>")
     $el.next().hide();
 
-    for user in Kandan.Data.ActiveUsers.all()
+    users = _(Kandan.Data.ActiveUsers.all()).chain().sortBy("username").reverse().sortBy("is_admin").reverse().value();
+
+    for user in users
       displayName   = null
       displayName   = user.username # Defaults to username
       displayName ||= user.email # Revert to user email address if that's all we have


### PR DESCRIPTION
Right now, users show in in the right panel almost at random -- I believe the correct order should be admins at the top, followed by non-admins, and then within those groups you sort by username. See below.

Before:

![screen shot 2014-12-08 at 2 15 55 pm](https://cloud.githubusercontent.com/assets/463175/5345343/18a55016-7ee5-11e4-8606-8be75d39ce97.png)

After:

![screen shot 2014-12-08 at 2 14 59 pm](https://cloud.githubusercontent.com/assets/463175/5345350/1dcb8948-7ee5-11e4-8e9a-fd5016f5bc02.png)
