### PR TITLE
Close notification onclick and focus tab accordingly

### DIFF
--- a/app/assets/javascripts/backbone/plugins/notifications.js.coffee
+++ b/app/assets/javascripts/backbone/plugins/notifications.js.coffee
@@ -141,6 +141,9 @@ class Kandan.Plugins.Notifications
           return
         ), 5000
         return
+      notification.onclick = (event) ->
+          window.focus()
+          event.currentTarget.close()
 
     if @fluid_notifications_enabled
       window.fluid.showGrowlNotification {


### PR DESCRIPTION
This one is another small one, but notifications should take you back to the tab they came from -- I swear I thought we had this, but I can't find it in the code. Oh well. This should solve #390 
