### PR TITLE
Made search a little easier for Kandan

### DIFF
--- a/app/assets/stylesheets/chat_area/_activity.sass
+++ b/app/assets/stylesheets/chat_area/_activity.sass
@@ -1,5 +1,11 @@
 .activities
   @extend %content-block
+  .no-results
+    padding: 10px 0
+    h2
+      text-align: center
+      margin-top: 20px
+      margin-bottom: 20px
 
 .activity
   background: #FFF

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -10,7 +10,7 @@ class MainController < ApplicationController
     minimum_query_length = 3
 
     if params[:query] and params[:query].length >= minimum_query_length
-      @activities = Activity.includes(:user).where("content LIKE ?", "%#{params[:query]}%").limit(params[:limit] || 100).all
+      @activities = Activity.includes(:user).where("LOWER(content) LIKE ?", "%#{params[:query]}%").limit(params[:limit] || 100).all
     end
 
     respond_to do |format|

--- a/app/views/main/_nav.html.erb
+++ b/app/views/main/_nav.html.erb
@@ -1,6 +1,6 @@
 <nav class="nav">
   <form class="search" method="get" action="/search">
-    <input type="text" class="query" name="query"/>
+    <input type="text" class="query" name="query" value="<%= params[:query].presence || "" %>" />
     <input type="submit" class="submit" value="Search">
   </form>
   <ul id="channel_nav"></ul>

--- a/app/views/main/search.html.erb
+++ b/app/views/main/search.html.erb
@@ -7,12 +7,21 @@
     Kandan.Plugins.initAll()
     activities = <%= json_escape(@activities.as_json(:include => { user: { :only => [:email, :first_name, :last_name, :username, :avatar_url, :gravatar_hash, :is_admin]} }).to_json.html_safe) %>;
 
-    $.each(activities, function(index, activityAttributes) {
-      activity = new Kandan.Models.Activity(activityAttributes);
-      activityView = new Kandan.Views.ShowActivity({activity: activity});
-      $(".activities").append(activityView.render().el);
-    })
+    if(activities.length){
+      $.each(activities, function(index, activityAttributes) {
+        activity = new Kandan.Models.Activity(activityAttributes);
+        activityView = new Kandan.Views.ShowActivity({activity: activity});
+        $(".activities").append(activityView.render().el);
+      })
+    }else{
+      $(".activities").append("<div class='no-results'><h2>No search results for '<%= params[:query] %>'</h2></div>");
+    }
+
   })
 <%- end %>
 
 <div class="activities"></div>
+
+<% content_for :end do %>
+  <%= render "nav" %>
+<% end %>


### PR DESCRIPTION
Before, when you searched for a term on Kandan, things were a little confusing with no results. Now, not only can a user see there was no results, but also easily search again for a new term.

Before:

![screen shot 2015-01-13 at 3 33 55 pm](https://cloud.githubusercontent.com/assets/463175/5728636/b4710736-9b39-11e4-9625-d9fe2faffcef.png)

After:

![screen shot 2015-01-13 at 3 33 34 pm](https://cloud.githubusercontent.com/assets/463175/5728644/b890b942-9b39-11e4-87fb-66d4f98c9e78.png)
